### PR TITLE
#2 fix

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -115,6 +115,9 @@ Parser.prototype.load = function(cb, fail, cacheId) {
 
 	this.loadCache(function(err, item) {
 		if (err || item) {
+			if (typeof item === 'string') {
+				return cb(item);
+			}
 			return cb(err, item);
 		} else {
 			fail(function(err, item) {
@@ -296,11 +299,11 @@ Parser.prototype.requestFacebook = function(cb, id) {
 	var self = this;
 	FB.napi(id, function(err, res) {
 		if (err) {
-			return cb(err);
+			return cb('video.invalid_url');
 		}
 
 		if (res.published === false) {
-			return cb('validate.forbidden_video');
+			return cb('video.forbidden');
 		}
 
 		var thumbnail = _.first(_.filter(res.format, function(item) {


### PR DESCRIPTION
- 공통된 error type (video.invalid_url) 반환하도록 수정.
- 오류 메시지 캐싱될 경우 발생하는 타입 에러 수정.
