### PR TITLE
remove redis dep + add html5 parser

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -153,6 +153,12 @@ Parser.SERVICES = [
     pattern: /(https?:\/\/)?\/\/(www.)?gomtv.com\/(\w+)/,
     method: 'loadGomTv',
     index: 3
+  },
+  {
+    provider: 'html5',
+    pattern: /(https?:\/\/).*\.(mp4|avi|mov)/,
+    method: 'loadHtml5',
+    index: 0
   }
 ]
 
@@ -327,6 +333,34 @@ Parser.prototype.loadGomTv = function (cb, id) {
   this.load(cb, function (Cb) {
     self.requestGomTv(cb, id)
   }, 'gomtv_' + id)
+}
+
+
+Parser.prototype.loadHtml5 = function (cb, id) {
+  var self = this
+
+  this.load(cb, function (cb) {
+    self.requestHtml5(cb, id)
+  }, 'html5_' + id)
+}
+
+
+const getTitle = fileName => fileName.substring(fileName.lastIndexOf('/') + 1, fileName.lastIndexOf('.'));
+
+Parser.prototype.requestHtml5 = function (cb, id) {
+  ffmpeg.ffprobe(id, function(err, metadata) {
+    if (err) {
+      cb(err);
+      return;
+    }
+    cb(null, {
+      id: id,
+      url: id,
+      name: getTitle(id),
+      duration: metadata.format.duration,
+      ctime: moment(metadata.format.tags.creation_time).format(),
+    })
+  });
 }
 
 Parser.prototype.requestYoutube = function (cb, id) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -9,12 +9,14 @@ var events = require('events')
 var request = require('request')
 var FB = require('fb')
 var ffmpeg = require('fluent-ffmpeg')
-var redis = require('redis')
 var defaults = require('merge-defaults')
 var moment = require('moment')
 var async = require('async')
 var cheerio = require('cheerio')
 var qs = require('querystring')
+
+// naive cache instead of REDIS
+const CACHE = {};
 
 /**
  * @param {object} config
@@ -36,10 +38,6 @@ function Parser (config) {
 
   config = defaults(config, {
     name: 'video-parser-cache',
-    redis: {
-      host: '127.0.0.1',
-      port: 6379
-    },
     youtube: {
       key: ''
     },
@@ -51,13 +49,6 @@ function Parser (config) {
     },
     ttl: 3600 * 12 // 1 day
   })
-  var options = config.redis.auth_pass ? {auth_pass: config.redis.auth_pass} : undefined
-  this._client = redis.createClient(config.redis.port, config.redis.host, options)
-  this._client.on('error', (function (self) {
-    return function (err) {
-      self.emit('error', err)
-    }
-  })(this))
 
   this._config = config
 }
@@ -1081,24 +1072,16 @@ Parser.prototype.requestGomTv = function (cb, id) {
 }
 
 Parser.prototype.loadCache = function (cb, cacheId) {
-  this._client.hget(this._config.name, cacheId, function (err, res) {
-    if (err || res === null) {
-      return cb(err, null)
-    }
-
-    var data = JSON.parse(res)
-    cb(null, data.ttl < Parser.now() ? null : data.item)
-  })
+  if (CACHE[cacheId]) {
+    cb(null, CACHE[cacheId])
+  } else {
+    cb(null)
+  }
 }
 
 Parser.prototype.saveCache = function (cb, cacheId, item, ttl) {
-  if (typeof ttl === 'undefined' || isNaN(ttl) === true) {
-    ttl = 3600 * 24 * 7
-  }
-  this._client.hset(this._config.name, cacheId, JSON.stringify({
-    item: item,
-    ttl: Parser.now(ttl)
-  }), cb)
+  CACHE[cacheId] = item
+  cb();
 }
 
 Parser.now = function (ttl) {


### PR DESCRIPTION
Hey,

Not sure you'll like these changes but let's discuss how this changes could go upstream.

- Redis dependency : overkill for small setups. i just removed it in favor of in-memory cache but i guess we could make this configurable ? (cache-backend setting)

- html5 parser : use ffmpeg to fetch and get html5 metadata